### PR TITLE
Check branch naming convention for branches associated with pull requests.

### DIFF
--- a/.github/workflows/check-hop-branch-name.yml
+++ b/.github/workflows/check-hop-branch-name.yml
@@ -1,0 +1,15 @@
+name: check-branch-name
+
+on:
+  pull_request
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: check HOP ticket number in the branch
+      if: contains(github.head_ref, 'HOP-') == false
+      run: echo "branch name doesn't have HOP- ticket number"; exit 1


### PR DESCRIPTION
This request enables github actions to checks if your PR's branch contains HOP ticket number somewhere.

This action is only run on pull requests so you are still able to push experimental branches (the ones you don't intend to merge) with non standard names.

Please merge it at your convenience.